### PR TITLE
SonarQ Recomendations

### DIFF
--- a/Auth.Infraestructure.Identity/DTOs/Email/SendEmailPartialRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Email/SendEmailPartialRequestDto.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Auth.Infraestructure.Identity.DTOs.Email
+﻿namespace Auth.Infraestructure.Identity.DTOs.Email
 {
     public class SendEmailPartialRequestDto
     {

--- a/Auth.Infraestructure.Identity/DTOs/Email/SendEmailRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Email/SendEmailRequestDto.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Auth.Infraestructure.Identity.DTOs.Email
+﻿namespace Auth.Infraestructure.Identity.DTOs.Email
 {
     public class SendEmailRequestDto
     {

--- a/Auth.Infraestructure.Identity/Extra/ExtraMethods.cs
+++ b/Auth.Infraestructure.Identity/Extra/ExtraMethods.cs
@@ -10,13 +10,11 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.IdentityModel.Tokens;
 using MimeKit;
 using Newtonsoft.Json;
-using Org.BouncyCastle.Asn1.Ocsp;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Security;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 
 namespace Auth.Infraestructure.Identity.Extra
 {

--- a/Auth.Infraestructure.Identity/Features/AuthenticateEmail/Command/AuthEmail/AuthEmailCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/AuthenticateEmail/Command/AuthEmail/AuthEmailCommand.cs
@@ -31,7 +31,7 @@ namespace Auth.Infraestructure.Identity.Features.AuthenticateEmail.Command.AuthE
 
         public async Task<GenericApiResponse<string>> Handle(AuthEmailCommand request, CancellationToken cancellationToken)
         {
-            var response = new GenericApiResponse<string>() 
+            var response = new GenericApiResponse<string>()
             {
                 Success = false,
                 Statuscode = StatusCodes.Status500InternalServerError,

--- a/Auth.Infraestructure.Identity/Features/Password/Commads/ChangePasswordCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Password/Commads/ChangePasswordCommand.cs
@@ -6,11 +6,8 @@ using Auth.Infraestructure.Identity.Extra;
 using Auth.Infraestructure.Identity.Mails;
 using Auth.Infraestructure.Identity.Settings;
 using MediatR;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
-using System.Net.Http;
-using System.Security.Cryptography.Xml;
 
 namespace Auth.Infraestructure.Identity.Features.Password.Commads
 {

--- a/Auth.Infraestructure.Identity/Features/Register/Commands/SendValidationEmailAgain/SendValidationEmailAgainCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Register/Commands/SendValidationEmailAgain/SendValidationEmailAgainCommand.cs
@@ -26,12 +26,6 @@ namespace Auth.Infraestructure.Identity.Features.Register.Commands.SendValidatio
         /// The origin of the request, typically used for creating the verification URL.
         /// </summary>
         public required string Origin { get; set; }
-
-        /// <summary>
-        /// Gets or sets the data transfer object (DTO) containing the required information 
-        /// for the email.
-        /// </summary>
-        //public required SendEmailPartialRequestDto EmailDto { get; set; }
     }
 
     internal class SendValidationEmailAgainCommandHandler(UserManager<ApplicationUser> userManager, MailSettings mailSettings) : IRequestHandler<SendValidationEmailAgainCommand, GenericApiResponse<string>>

--- a/Auth.Testing.AuthAPI/Controllers/AccountController.cs
+++ b/Auth.Testing.AuthAPI/Controllers/AccountController.cs
@@ -47,7 +47,7 @@ namespace Auth.Testing.AuthAPI.Controllers
             var request = new CreateAccountCommand(Roles.User.ToString())
             {
                 Dto = requestDto,
-                ORIGIN = Request.Headers.Origin.ToString() ?? "Unknown"
+                Origin = Request.Headers.Origin.ToString() ?? "Unknown"
             };
             var response = await Mediator.Send(request);
             return StatusCode(response.Statuscode, response);

--- a/Auth.Testing.AuthAPI/Controllers/AccountController.cs
+++ b/Auth.Testing.AuthAPI/Controllers/AccountController.cs
@@ -1,7 +1,5 @@
 using Auth.Infraestructure.Identity.DTOs.Account;
-using Auth.Infraestructure.Identity.DTOs.Email;
 using Auth.Infraestructure.Identity.DTOs.Password;
-using Auth.Infraestructure.Identity.Extra;
 using Auth.Infraestructure.Identity.Features.AuthenticateEmail.Command.AuthEmail;
 using Auth.Infraestructure.Identity.Features.Login.Queries.AuthLogin;
 using Auth.Infraestructure.Identity.Features.Password.Commads;
@@ -16,8 +14,6 @@ using Auth.Testing.AuthAPI.ExtraConfig.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Net.Http;
 using System.Security.Cryptography;
 
 namespace Auth.Testing.AuthAPI.Controllers


### PR DESCRIPTION

This pull request refactors the `CreateAccountCommand` and `SendValidationEmailAgainCommand` classes to standardize property naming and streamline email handling. 
- `CreateAccountCommand.cs`: Renamed `ORIGIN` to `Origin` and removed `EmailDto` property.
- `SendValidationEmailAgainCommand.cs`: Renamed `ORIGIN` to `Origin` and removed `EmailDto` property.
- Updated email verification logic to use the new `Origin` property.
- `AccountController.cs`: Updated request object to use the new `Origin` property.
- Added a new using directive for `Auth.Infraestructure.Identity.Mails`.
