### PR TITLE
Changes for SonarQ Problems:

### DIFF
--- a/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
@@ -14,6 +14,7 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
     {
         public required ChangeEmailRequestDto Dto { get; set; }
         public required string UserId { get; set; }
+        public bool UseOtp { get; set; } = false;
     }
 
     internal class ChangeEmailCommandHandler(UserManager<ApplicationUser> userManager,
@@ -49,7 +50,7 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
                     return response;
                 }
 
-                if (request.Dto.Otp is not null)
+                if (request.Dto.Otp is not null && request.UseOtp)
                 {
                     var otpCheckResponse = await ValidateOtpWithEmail(response, request);
                     if (!otpCheckResponse.Success)

--- a/Auth.Testing.AuthAPI/Controllers/AccountController.cs
+++ b/Auth.Testing.AuthAPI/Controllers/AccountController.cs
@@ -256,6 +256,7 @@ namespace Auth.Testing.AuthAPI.Controllers
             {
                 Dto = requestDto,
                 UserId = User.FindFirst("uid")!.Value,
+                UseOtp = true
             };
             var response = await Mediator.Send(request);
             return StatusCode(response.Statuscode, response);


### PR DESCRIPTION
Changes for SonarQ Problems:

Add UseOtp property for email change verification

Introduced a new `UseOtp` boolean property in the `ChangeEmailCommand` class to control OTP usage for email changes, defaulting to false. Updated OTP validation logic to check both the presence of an OTP and the `UseOtp` flag. Modified the `AccountController` to set `UseOtp` to true when creating a `ChangeEmailCommand` instance, ensuring OTP verification is utilized.