### PR TITLE
New feature implementation for password management using OTP.

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -4,7 +4,7 @@ pipeline {
         NUGET_API_KEY = credentials('private_nuget_api_key')
         NUGET_SERVER_URL = credentials('private_nuget_uri')
         SONARQUBE_EXCLUDE_FILES = "**/*.xml,**/*.json,**/*.html,**/*.css,**/*.js,**/Program.cs,**/Startup.cs,**/Migrations/**"
-        VERSION = "0.1.4"
+        VERSION = "0.1.5"
     }
 
     stages {

--- a/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
+++ b/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\ForgotPSW\" />
+    <Folder Include="Features\ForgotPSW\Commands\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
+++ b/Auth.Infraestructure.Identity/Auth.Infraestructure.Identity.csproj
@@ -41,10 +41,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Features\ForgotPSW\Commands\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\ico.jpg">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>

--- a/Auth.Infraestructure.Identity/DTOs/Password/ChangePasswordWithOtpRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Password/ChangePasswordWithOtpRequestDto.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Auth.Infraestructure.Identity.DTOs.Password
+{
+    public class ChangePasswordWithOtpRequestDto
+    {
+        public required string NewPassword { get; set; }
+        public required string RepeatNewPassword { get; set; }
+        public required string Otp { get; set; }
+        public required string Email { get; set; }
+    }
+}

--- a/Auth.Infraestructure.Identity/DTOs/Password/PasswordChangeOtpRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Password/PasswordChangeOtpRequestDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Auth.Infraestructure.Identity.DTOs.Password
+{
+    public class PasswordChangeOtpRequestDto
+    {
+        public required string Email { get; set; }
+    }
+}

--- a/Auth.Infraestructure.Identity/Entities/MailOtp.cs
+++ b/Auth.Infraestructure.Identity/Entities/MailOtp.cs
@@ -1,4 +1,6 @@
-﻿namespace Auth.Infraestructure.Identity.Entities
+﻿using Auth.Infraestructure.Identity.Enums;
+
+namespace Auth.Infraestructure.Identity.Entities
 {
     public class MailOtp
     {
@@ -7,7 +9,9 @@
         public required string Otp { get; set; }
         public required string IpAddress { get; set; }
         public required string UserAgent { get; set; }
-        public required DateTime ExpirationDate { get; set; }
+        public required DateTime Expiration { get; set; }
+        public required string Purpose { get; set; }
+
         public bool? Used { get; set; } = false;
 
         public ApplicationUser? User { get; set; }

--- a/Auth.Infraestructure.Identity/Enums/OtpPurpose.cs
+++ b/Auth.Infraestructure.Identity/Enums/OtpPurpose.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Auth.Infraestructure.Identity.Enums
+{
+    internal enum OtpPurpose
+    {
+        PasswordReset,
+        ChangeEmail
+    }
+}

--- a/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
@@ -2,6 +2,7 @@
 using Auth.Infraestructure.Identity.DTOs.Email;
 using Auth.Infraestructure.Identity.DTOs.Generic;
 using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Enums;
 using Auth.Infraestructure.Identity.Extra;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -92,7 +93,9 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
         private async Task<GenericApiResponse<bool>> ValidateOtpWithEmail(GenericApiResponse<bool> response, ChangeEmailCommand request)
         {
             var otpRecord = await _identityContext.Set<MailOtp>()
-                .Where(x => x.UserId == request.UserId && x.Otp == ExtraMethods.HashToken(request.Dto.Otp!))
+                .Where(x => x.UserId == request.UserId 
+                    && x.Otp == ExtraMethods.HashToken(request.Dto.Otp!) 
+                    && x.Purpose == OtpPurpose.ChangeEmail.ToString())
                 .FirstOrDefaultAsync();
 
             if (otpRecord == null)
@@ -102,7 +105,7 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
                 return response;
             }
 
-            if (otpRecord.ExpirationDate < DateTime.UtcNow)
+            if (otpRecord.Expiration < DateTime.UtcNow)
             {
                 response.Message = "OTP has expired";
                 response.Statuscode = StatusCodes.Status406NotAcceptable;

--- a/Auth.Infraestructure.Identity/Features/Email/Commands/RequestEmailChangeOtpCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Email/Commands/RequestEmailChangeOtpCommand.cs
@@ -3,6 +3,7 @@ using Auth.Infraestructure.Identity.DTOs.Generic;
 using Auth.Infraestructure.Identity.DTOs.Mail;
 using Auth.Infraestructure.Identity.DTOs.Otp;
 using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Enums;
 using Auth.Infraestructure.Identity.Extra;
 using Auth.Infraestructure.Identity.Mails;
 using Auth.Infraestructure.Identity.Settings;
@@ -60,9 +61,10 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
                 {
                     UserId = user.Id,
                     Otp = ExtraMethods.HashToken(Otp),
-                    ExpirationDate = DateTime.UtcNow.AddMinutes(15),
+                    Expiration = DateTime.UtcNow.AddMinutes(15),
                     UserAgent = request.UserAgent,
-                    IpAddress = request.IpAddress
+                    IpAddress = request.IpAddress,
+                    Purpose = OtpPurpose.ChangeEmail.ToString()
                 });
                 await _identityContext.SaveChangesAsync(cancellationToken);
 

--- a/Auth.Infraestructure.Identity/Features/ForgotPSW/Commands/ChangePasswordWithOtpCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/ForgotPSW/Commands/ChangePasswordWithOtpCommand.cs
@@ -1,0 +1,101 @@
+﻿using Auth.Infraestructure.Identity.Context;
+using Auth.Infraestructure.Identity.DTOs.Generic;
+using Auth.Infraestructure.Identity.DTOs.Mail;
+using Auth.Infraestructure.Identity.DTOs.Password;
+using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Extra;
+using Auth.Infraestructure.Identity.Mails;
+using Auth.Infraestructure.Identity.Settings;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Auth.Infraestructure.Identity.Features.ForgotPSW.Commands
+{
+    public class ChangePasswordWithOtpCommand : IRequest<GenericApiResponse<bool>>
+    {
+        public required ChangePasswordWithOtpRequestDto Dto { get; set; }
+        public required string IpAddress { get; set; }
+        public required string UserAgent { get; set; }
+    }
+    internal class ChangePasswordWithOtpCommandHandler(UserManager<ApplicationUser> userManager,
+            MailSettings mailSettings,
+            IHttpClientFactory httpClientFactory,
+            IdentityContext identityContext) : IRequestHandler<ChangePasswordWithOtpCommand, GenericApiResponse<bool>>
+    {
+        private readonly MailSettings _mailSettings = mailSettings;
+        private readonly UserManager<ApplicationUser> _userManager = userManager;
+        private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+        private readonly IdentityContext _identityContext = identityContext;
+
+        public async Task<GenericApiResponse<bool>> Handle(ChangePasswordWithOtpCommand request, CancellationToken cancellationToken)
+        {
+            var response = new GenericApiResponse<bool>()
+            {
+                Payload = false,
+                Success = false,
+                Statuscode = StatusCodes.Status500InternalServerError,
+                Message = ""
+            };
+
+            var user = await _userManager.FindByEmailAsync(request.Dto.Email);
+            if (user == null)
+            {
+                response.Message = "User with that Email not found";
+                response.Statuscode = StatusCodes.Status404NotFound;
+                return response;
+            }
+
+            if (request.Dto.NewPassword != request.Dto.RepeatNewPassword)
+            {
+                response.Message = "Passwords do not match";
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+                return response;
+            }
+
+            if (await _userManager.CheckPasswordAsync(user, request.Dto.NewPassword))
+            {
+                response.Message = "New password cannot be the same as the current password";
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+                return response;
+            }
+            var passwordReset = await _userManager.GeneratePasswordResetTokenAsync(user);
+            var result = await _userManager.ResetPasswordAsync(user, passwordReset, request.Dto.NewPassword);
+
+            if (result.Succeeded)
+            {
+                response.Payload = true;
+                response.Success = true;
+                response.Statuscode = StatusCodes.Status200OK;
+                response.Message = "Password changed successfully";
+
+                if (request.UserAgent != null && request.IpAddress != null)
+                {
+                    var geoInfo = await ExtraMethods.GetGeoLocationInfo(request.IpAddress, _httpClientFactory);
+                    await ExtraMethods.SendEmail(_mailSettings, new SendEmailRequestDto
+                    {
+                        To = user.Email!,
+                        Body = ChangePasswordMail.GetEmailHtml(request.IpAddress, geoInfo?.Country ?? "", request.UserAgent),
+                        Subject = "Password Changed"
+                    });
+                }
+            }
+            else
+            {
+                foreach (var error in result.Errors)
+                {
+                    response.Message += " " + error.Description;
+                }
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+            }
+
+            return response;
+        }
+    }
+}

--- a/Auth.Infraestructure.Identity/Mails/PasswordResetEmail.cs
+++ b/Auth.Infraestructure.Identity/Mails/PasswordResetEmail.cs
@@ -1,0 +1,37 @@
+﻿namespace Auth.Infraestructure.Identity.Mails
+{
+    public class PasswordResetEmail
+    {
+        public required string UserName { get; set; }
+        public required string OtpCode { get; set; }
+        public required string Ip { get; set; }
+        public required string Country { get; set; }
+        public required string UserAgent { get; set; }
+
+        public virtual string GetEmailHtml()
+        {
+            return $@"<!DOCTYPE html>
+                        <html lang='en'>
+                        <head>
+                            <meta charset='UTF-8'>
+                            <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+                            <title>Password Reset Request</title>
+                        </head>
+                        <body>
+                            <h2>Password Reset Request</h2>
+                            <p>Hello {UserName},</p>
+                            <p>You have requested to reset your password. Use the following One-Time Password (OTP) to proceed:</p>
+                            <p><strong>Your OTP Code:</strong> {OtpCode}</p>
+                            <p><strong>Request Details:</strong></p>
+                            <ul>
+                                <li><strong>IP Address:</strong> {Ip}</li>
+                                <li><strong>Location:</strong> {Country}</li>
+                                <li><strong>Browser and OS:</strong> {UserAgent}</li>
+                            </ul>
+                            <p>If you did not request this, please ignore this email or contact our support team.</p>
+                            <p>&copy; 2025 AbreuHD. All rights reserved.</p>
+                        </body>
+                        </html>";
+        }
+    }
+}

--- a/Auth.Infraestructure.Identity/Migrations/20250227204928_Purpose added to Otp.Designer.cs
+++ b/Auth.Infraestructure.Identity/Migrations/20250227204928_Purpose added to Otp.Designer.cs
@@ -4,6 +4,7 @@ using Auth.Infraestructure.Identity.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Auth.Infraestructure.Identity.Migrations
 {
     [DbContext(typeof(IdentityContext))]
-    partial class IdentityContextModelSnapshot : ModelSnapshot
+    [Migration("20250227204928_Purpose added to Otp")]
+    partial class PurposeaddedtoOtp
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Auth.Infraestructure.Identity/Migrations/20250227204928_Purpose added to Otp.cs
+++ b/Auth.Infraestructure.Identity/Migrations/20250227204928_Purpose added to Otp.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Auth.Infraestructure.Identity.Migrations
+{
+    /// <inheritdoc />
+    public partial class PurposeaddedtoOtp : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ExpirationDate",
+                table: "MailOtp",
+                newName: "Expiration");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Purpose",
+                table: "MailOtp",
+                type: "longtext",
+                nullable: false)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Purpose",
+                table: "MailOtp");
+
+            migrationBuilder.RenameColumn(
+                name: "Expiration",
+                table: "MailOtp",
+                newName: "ExpirationDate");
+        }
+    }
+}

--- a/Auth.Testing.AuthAPI/Controllers/AccountController.cs
+++ b/Auth.Testing.AuthAPI/Controllers/AccountController.cs
@@ -5,6 +5,7 @@ using Auth.Infraestructure.Identity.DTOs.Password;
 using Auth.Infraestructure.Identity.DTOs.UserName;
 using Auth.Infraestructure.Identity.Features.AuthenticateEmail.Command.AuthEmail;
 using Auth.Infraestructure.Identity.Features.Email.Commands;
+using Auth.Infraestructure.Identity.Features.ForgotPSW.Commands;
 using Auth.Infraestructure.Identity.Features.Login.Queries.AuthLogin;
 using Auth.Infraestructure.Identity.Features.Password.Commads;
 using Auth.Infraestructure.Identity.Features.Register.Commands.CreateAccount;
@@ -257,6 +258,20 @@ namespace Auth.Testing.AuthAPI.Controllers
                 Dto = requestDto,
                 UserId = User.FindFirst("uid")!.Value,
                 UseOtp = true
+            };
+            var response = await Mediator.Send(request);
+            return StatusCode(response.Statuscode, response);
+        }
+
+        [HttpPut("GeneratePasswordResetOtp")]
+        [Authorize]
+        public async Task<IActionResult> GeneratePasswordResetOtp(PasswordChangeOtpRequestDto requestDto)
+        {
+            var request = new GeneratePasswordResetOtpCommand()
+            {
+                Dto = requestDto,
+                IpAddress = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "Unknown",
+                UserAgent = Request.Headers.UserAgent.ToString()
             };
             var response = await Mediator.Send(request);
             return StatusCode(response.Statuscode, response);


### PR DESCRIPTION
#### PR Summary
This pull request introduces new functionality for password changes and resets using One-Time Passwords (OTPs). Key changes include:
- `ChangePasswordWithOtpRequestDto` and `PasswordChangeOtpRequestDto` classes added for handling OTP-based password changes.
- `MailOtp` entity updated to rename `ExpirationDate` to `Expiration` and add a new `Purpose` property.
- New `OtpPurpose` enum created to define OTP purposes like `PasswordReset` and `ChangeEmail`.
- `ChangePasswordWithOtpCommand` and `GeneratePasswordResetOtpCommand` classes added to manage OTP generation and password changes.
- `AccountController` updated with a new endpoint for generating password reset OTPs.
