### PR TITLE
New feature to implement email change functionality with OTP validation.

### DIFF
--- a/Auth.Infraestructure.Identity/DTOs/Email/ChangeEmailWithOtpRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Email/ChangeEmailWithOtpRequestDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Auth.Infraestructure.Identity.DTOs.Email
+{
+    public class ChangeEmailWithOtpRequestDto
+    {
+        public required string NewEmail { get; set; }
+        public required string Otp { get; set; }
+    }
+}

--- a/Auth.Infraestructure.Identity/Otp/ValidateOtpEmail.cs
+++ b/Auth.Infraestructure.Identity/Otp/ValidateOtpEmail.cs
@@ -1,0 +1,53 @@
+﻿using Auth.Infraestructure.Identity.Context;
+using Auth.Infraestructure.Identity.DTOs.Generic;
+using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Enums;
+using Auth.Infraestructure.Identity.Extra;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Auth.Infraestructure.Identity.Otp
+{
+    internal static class ValidateOtpEmail
+    {
+        internal static async Task<GenericApiResponse<bool>> ValidateOtpWithEmail(GenericApiResponse<bool> response, string otp, string userId, string purpose, IdentityContext _identityContext)
+        {
+            var otpRecord = await _identityContext.Set<MailOtp>()
+                .Where(x => x.UserId == userId
+                    && x.Otp == ExtraMethods.HashToken(otp)
+                    && x.Purpose == purpose)
+                .FirstOrDefaultAsync();
+
+            if (otpRecord == null)
+            {
+                response.Message = "Invalid OTP";
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+                return response;
+            }
+
+            if (otpRecord.Expiration < DateTime.UtcNow)
+            {
+                response.Message = "OTP has expired";
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+                return response;
+            }
+
+            if (otpRecord.Used == true)
+            {
+                response.Message = "OTP has already been used";
+                response.Statuscode = StatusCodes.Status406NotAcceptable;
+                return response;
+            }
+
+            otpRecord.Used = true;
+            _identityContext.Entry(otpRecord).Property(o => o.Used).IsModified = true;
+            await _identityContext.SaveChangesAsync();
+
+            response.Success = true;
+            return response;
+        }
+    }
+}

--- a/Auth.Testing.AuthAPI/Controllers/AccountController.cs
+++ b/Auth.Testing.AuthAPI/Controllers/AccountController.cs
@@ -251,13 +251,12 @@ namespace Auth.Testing.AuthAPI.Controllers
 
         [HttpPut("ChangeEmailWithOtp")]
         [Authorize]
-        public async Task<IActionResult> ChangeEmailWithOtp(ChangeEmailRequestDto requestDto)
+        public async Task<IActionResult> ChangeEmailWithOtp(ChangeEmailWithOtpRequestDto requestDto)
         {
-            var request = new ChangeEmailCommand()
+            var request = new ChangeEmailWithOtpCommand()
             {
                 Dto = requestDto,
                 UserId = User.FindFirst("uid")!.Value,
-                UseOtp = true
             };
             var response = await Mediator.Send(request);
             return StatusCode(response.Statuscode, response);


### PR DESCRIPTION
This pull request introduces a new DTO and command structure for changing email addresses using OTP validation, centralizing the OTP validation logic. 
- `ChangeEmailWithOtpRequestDto` added to handle email change requests with OTP.
- `ChangeEmailCommand.cs` modified to remove unused properties and simplify logic.
- New static class `ValidateOtpEmail` created for centralized OTP validation.
- `ChangeEmailWithOtpCommand.cs` added to manage email change requests with OTP.
- `AccountController.cs` updated to utilize the new DTO and command for email change endpoint.
