### PR TITLE
Refactor email change logic and DTOs

### DIFF
--- a/Auth.Infraestructure.Identity/DTOs/Email/ChangeEmailRequestDto.cs
+++ b/Auth.Infraestructure.Identity/DTOs/Email/ChangeEmailRequestDto.cs
@@ -3,7 +3,6 @@
     public class ChangeEmailRequestDto
     {
         public required string NewEmail { get; set; }
-        public string? Password { get; set; }
-        public string? Otp { get; set; }
+        public required string Password { get; set; }
     }
 }

--- a/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailCommand.cs
@@ -1,6 +1,7 @@
 ﻿using Auth.Infraestructure.Identity.DTOs.Email;
 using Auth.Infraestructure.Identity.DTOs.Generic;
 using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Services;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -14,59 +15,11 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
     }
     internal class ChangeEmailCommandHandler(UserManager<ApplicationUser> userManager) : IRequestHandler<ChangeEmailCommand, GenericApiResponse<bool>>
     {
-        private readonly UserManager<ApplicationUser> _userManager = userManager;
+        private readonly EmailChangeService _emailChangeService = new(userManager);
 
         public async Task<GenericApiResponse<bool>> Handle(ChangeEmailCommand request, CancellationToken cancellationToken)
         {
-            var response = new GenericApiResponse<bool>()
-            {
-                Payload = false,
-                Success = false,
-                Statuscode = StatusCodes.Status500InternalServerError,
-                Message = ""
-            };
-            try
-            {
-                var user = await _userManager.FindByIdAsync(request.UserId);
-                if (user == null)
-                {
-                    response.Message = "User not found.";
-                    response.Statuscode = StatusCodes.Status404NotFound;
-                    return response;
-                }
-                var UserNameExist = await _userManager.FindByEmailAsync(request.Dto.NewEmail);
-                if (UserNameExist != null)
-                {
-                    response.Success = false;
-                    response.Message = $"Email {request.Dto.NewEmail} is already taken";
-                    response.Statuscode = StatusCodes.Status406NotAcceptable;
-                    return response;
-                }
-                var passwordCheck = await _userManager.CheckPasswordAsync(user, request.Dto.Password!);
-                if (!passwordCheck)
-                {
-                    response.Message = "Password is incorrect";
-                    response.Statuscode = StatusCodes.Status406NotAcceptable;
-                    return response;
-                }
-                var result = await _userManager.SetEmailAsync(user, request.Dto.NewEmail);
-                if (result.Succeeded)
-                {
-                    response.Payload = true;
-                    response.Success = true;
-                    response.Statuscode = StatusCodes.Status200OK;
-                    response.Message = "Email changed successfully.";
-                }
-                else
-                {
-                    response.Message = string.Join(", ", result.Errors.Select(e => e.Description));
-                }
-            }
-            catch (Exception ex)
-            {
-                response.Message = ex.Message;
-            }
-            return response;
+            return await _emailChangeService.ChangeEmailAsync(request.UserId, request.Dto.NewEmail, request.Dto.Password);
         }
     }
 }

--- a/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailWithOtpCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/Email/Commands/ChangeEmailWithOtpCommand.cs
@@ -4,6 +4,7 @@ using Auth.Infraestructure.Identity.DTOs.Generic;
 using Auth.Infraestructure.Identity.Entities;
 using Auth.Infraestructure.Identity.Enums;
 using Auth.Infraestructure.Identity.Otp;
+using Auth.Infraestructure.Identity.Services;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -18,60 +19,11 @@ namespace Auth.Infraestructure.Identity.Features.Email.Commands
     internal class ChangeEmailWithOtpCommandHandler(UserManager<ApplicationUser> userManager,
             IdentityContext identityContext) : IRequestHandler<ChangeEmailWithOtpCommand, GenericApiResponse<bool>>
     {
-        private readonly UserManager<ApplicationUser> _userManager = userManager;
-        private readonly IdentityContext _identityContext = identityContext;
+        private readonly EmailChangeService _emailChangeService = new(userManager,identityContext);
 
         public async Task<GenericApiResponse<bool>> Handle(ChangeEmailWithOtpCommand request, CancellationToken cancellationToken)
         {
-            var response = new GenericApiResponse<bool>()
-            {
-                Payload = false,
-                Success = false,
-                Statuscode = StatusCodes.Status500InternalServerError,
-                Message = ""
-            };
-            try
-            {
-                var user = await _userManager.FindByIdAsync(request.UserId);
-                if (user == null)
-                {
-                    response.Message = "User not found.";
-                    response.Statuscode = StatusCodes.Status404NotFound;
-                    return response;
-                }
-                var UserNameExist = await _userManager.FindByEmailAsync(request.Dto.NewEmail);
-                if (UserNameExist != null)
-                {
-                    response.Success = false;
-                    response.Message = $"Email {request.Dto.NewEmail} is already taken";
-                    response.Statuscode = StatusCodes.Status406NotAcceptable;
-                    return response;
-                }
-
-                var otpCheckResponse = await ValidateOtpEmail.ValidateOtpWithEmail(response, request.Dto.Otp, user.Id, OtpPurpose.ChangeEmail.ToString(), _identityContext);
-                if (!otpCheckResponse.Success)
-                {
-                    return otpCheckResponse;
-                }
-
-                var result = await _userManager.SetEmailAsync(user, request.Dto.NewEmail);
-                if (result.Succeeded)
-                {
-                    response.Payload = true;
-                    response.Success = true;
-                    response.Statuscode = StatusCodes.Status200OK;
-                    response.Message = "Email changed successfully.";
-                }
-                else
-                {
-                    response.Message = string.Join(", ", result.Errors.Select(e => e.Description));
-                }
-            }
-            catch (Exception ex)
-            {
-                response.Message = ex.Message;
-            }
-            return response;
+            return await _emailChangeService.ChangeEmailAsync(request.UserId, request.Dto.NewEmail, otp: request.Dto.Otp);
         }
     }
 }

--- a/Auth.Infraestructure.Identity/Services/EmailChangeService.cs
+++ b/Auth.Infraestructure.Identity/Services/EmailChangeService.cs
@@ -1,0 +1,91 @@
+﻿using Auth.Infraestructure.Identity.Context;
+using Auth.Infraestructure.Identity.DTOs.Generic;
+using Auth.Infraestructure.Identity.Entities;
+using Auth.Infraestructure.Identity.Enums;
+using Auth.Infraestructure.Identity.Otp;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+
+namespace Auth.Infraestructure.Identity.Services
+{
+    public class EmailChangeService(UserManager<ApplicationUser> userManager, IdentityContext? identityContext = null)
+    {
+        private readonly UserManager<ApplicationUser> _userManager = userManager;
+        private readonly IdentityContext? _identityContext = identityContext;
+
+        public async Task<GenericApiResponse<bool>> ChangeEmailAsync(string userId, string newEmail, string? password = null, string? otp = null)
+        {
+            var response = new GenericApiResponse<bool>
+            {
+                Payload = false,
+                Success = false,
+                Statuscode = StatusCodes.Status500InternalServerError,
+                Message = ""
+            };
+
+            try
+            {
+                var user = await _userManager.FindByIdAsync(userId);
+                if (user == null)
+                {
+                    response.Message = "User not found.";
+                    response.Statuscode = StatusCodes.Status404NotFound;
+                    return response;
+                }
+
+                var emailExists = await _userManager.FindByEmailAsync(newEmail);
+                if (emailExists != null)
+                {
+                    response.Message = $"Email {newEmail} is already taken.";
+                    response.Statuscode = StatusCodes.Status406NotAcceptable;
+                    return response;
+                }
+
+                if (!string.IsNullOrEmpty(otp))
+                {
+                    if (_identityContext == null)
+                    {
+                        response.Message = "OTP validation requires IdentityContext.";
+                        return response;
+                    }
+
+                    var otpCheckResponse = await ValidateOtpEmail.ValidateOtpWithEmail(response, otp, user.Id, OtpPurpose.ChangeEmail.ToString(), _identityContext);
+                    if (!otpCheckResponse.Success)
+                    {
+                        return otpCheckResponse;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(password))
+                {
+                    var passwordCheck = await _userManager.CheckPasswordAsync(user, password);
+                    if (!passwordCheck)
+                    {
+                        response.Message = "Password is incorrect.";
+                        response.Statuscode = StatusCodes.Status406NotAcceptable;
+                        return response;
+                    }
+                }
+
+                var result = await _userManager.SetEmailAsync(user, newEmail);
+                if (result.Succeeded)
+                {
+                    response.Payload = true;
+                    response.Success = true;
+                    response.Statuscode = StatusCodes.Status200OK;
+                    response.Message = "Email changed successfully.";
+                }
+                else
+                {
+                    response.Message = string.Join(", ", result.Errors.Select(e => e.Description));
+                }
+            }
+            catch (Exception ex)
+            {
+                response.Message = ex.Message;
+            }
+
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
- Updated `ChangeEmailRequestDto` to require `Password` and removed `Otp`.
- Refactored `ChangeEmailCommandHandler` to use `EmailChangeService` for email changes.
- Updated `ChangeEmailWithOtpCommandHandler` to utilize `EmailChangeService`.
- Introduced `EmailChangeService` to centralize email change logic, including OTP validation and user checks.
- Improved separation of concerns and reusability across command handlers.
closes #6 