### PR TITLE
Update version and enhance logout security

### DIFF
--- a/.Jenkinsfiles/TestJenkins
+++ b/.Jenkinsfiles/TestJenkins
@@ -4,7 +4,7 @@ pipeline {
         NUGET_API_KEY = credentials('private_nuget_api_key')
         NUGET_SERVER_URL = credentials('private_nuget_uri')
         SONARQUBE_EXCLUDE_FILES = "**/*.xml,**/*.json,**/*.html,**/*.css,**/*.js,**/Program.cs,**/Startup.cs,**/Migrations/**"
-        VERSION = "1.0.3"
+        VERSION = "1.0.4"
     }
 
     stages {

--- a/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutCurrentSessionCommand.cs
+++ b/Auth.Infraestructure.Identity/Features/UserSessions/Commands/LogoutCurrentSessionCommand.cs
@@ -1,8 +1,10 @@
 ﻿using Auth.Infraestructure.Identity.Context;
 using Auth.Infraestructure.Identity.DTOs.Generic;
+using Auth.Infraestructure.Identity.Extra;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 
 
 namespace Auth.Infraestructure.Identity.Features.UserSessions.Commands
@@ -27,7 +29,8 @@ namespace Auth.Infraestructure.Identity.Features.UserSessions.Commands
 
         public async Task<GenericApiResponse<bool>> Handle(LogoutCurrentSessionCommand request, CancellationToken cancellationToken)
         {
-            var identityResponse = await _identityContext.Set<Entities.UserSession>().FirstOrDefaultAsync(x => x.Token == request.Token, cancellationToken);
+            var hashedToken = ExtraMethods.HashToken(request.Token);
+            var identityResponse = await _identityContext.Set<Entities.UserSession>().FirstOrDefaultAsync(x => x.Token == hashedToken, cancellationToken);
             if (identityResponse == null)
             {
                 return new GenericApiResponse<bool>


### PR DESCRIPTION
Update version and enhance logout security

- Bump Jenkins pipeline version from 1.0.3 to 1.0.4.
- Add using directives for `Auth.Infraestructure.Identity.Extra` and `Newtonsoft.Json.Linq` in `LogoutCurrentSessionCommand.cs`.
- Modify logout session handling to hash the token before database query for improved security.